### PR TITLE
Handle libasound rename

### DIFF
--- a/autonomous-ai-server/UBUNTU-SETUP.md
+++ b/autonomous-ai-server/UBUNTU-SETUP.md
@@ -62,7 +62,10 @@ sudo apt install -y curl wget git build-essential
 
 # Puppeteer dependencies for browser automation
 sudo apt install -y \
-    ca-certificates fonts-liberation libappindicator3-1 libasound2 \
+    ca-certificates fonts-liberation libappindicator3-1 \
+    # libasound2t64 is used on Ubuntu 24.04. Older releases use libasound2.
+    \
+    $(apt-cache show libasound2t64 >/dev/null 2>&1 && echo libasound2t64 || echo libasound2) \
     libatk-bridge2.0-0 libatk1.0-0 libc6 libcairo2 libcups2 \
     libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 \
     libglib2.0-0 libgtk-3-0 libnspr4 libnss3 libpango-1.0-0 \

--- a/autonomous-ai-server/setup-ubuntu.sh
+++ b/autonomous-ai-server/setup-ubuntu.sh
@@ -58,11 +58,20 @@ print_success "npm installed: $NPM_VERSION"
 
 # Install additional dependencies for Puppeteer
 print_status "Installing Puppeteer dependencies..."
+
+# libasound2 was renamed to libasound2t64 starting with Ubuntu 24.04.
+# Check for the new package first and fall back to libasound2 on older systems.
+if apt-cache show libasound2t64 >/dev/null 2>&1; then
+    ALSA_PACKAGE="libasound2t64"
+else
+    ALSA_PACKAGE="libasound2"
+fi
+
 sudo apt install -y \
     ca-certificates \
     fonts-liberation \
     libappindicator3-1 \
-    libasound2 \
+    "$ALSA_PACKAGE" \
     libatk-bridge2.0-0 \
     libatk1.0-0 \
     libc6 \


### PR DESCRIPTION
## Summary
- install `libasound2t64` when available
- document the new package name in setup instructions

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden when fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_6849f58b702883298c2a1a7e7fdffaef