### PR TITLE
Update docs for npm warnings

### DIFF
--- a/UBUNTU-SETUP.md
+++ b/UBUNTU-SETUP.md
@@ -86,6 +86,11 @@ cd ~/autonomous-ai-server
 # Then install dependencies
 npm install
 
+> **Note**: During installation you may see `npm WARN deprecated` messages for
+> some nested packages (e.g. `glob@7` or `inflight`). These come from the
+> dependency tree of third‑party packages and do not affect the functionality
+> of the server. They can safely be ignored.
+
 # Build the project
 npm run build
 ```

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "cheerio": "^1.0.0-rc.12",
     "fs-extra": "^11.2.0",
     "glob": "^10.3.0",
-    "puppeteer": "^21.0.0",
+    "puppeteer": "^22.8.2",
     "lighthouse": "^11.0.0",
     "ws": "^8.14.0"
   },
@@ -33,7 +33,7 @@
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",
     "tsx": "^4.0.0",
-    "eslint": "^8.0.0",
+    "eslint": "^9.0.0",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "typescript": "^5.0.0"


### PR DESCRIPTION
## Summary
- mention safe npm warnings in UBUNTU-SETUP guide
- bump puppeteer
- bump eslint

## Testing
- `npm run build` *(fails: Cannot find modules)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849feefa67c83299892161bc5880939