### PR TITLE
Fix eslint version conflict for npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",
     "tsx": "^4.0.0",
-    "eslint": "^9.0.0",
+    "eslint": "^8.0.0",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "typescript": "^5.0.0"


### PR DESCRIPTION
## Summary
- downgrade eslint from 9.x to 8.x to satisfy `@typescript-eslint/parser` peer
  dependency

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a0036e70c83298c83a68bc46c8d00