### PR TITLE
Fix cheerio usage and typing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3751,7 +3751,7 @@ class AutonomousAIServer {
       $('script, style, noscript').remove();
       
       // Get text content and clean it up
-      const textContent = $.text()
+      const textContent = $.root().text()
         .replace(/\s+/g, ' ') // Replace multiple whitespace with single space
         .replace(/\n\s*\n/g, '\n') // Replace multiple newlines with single newline
         .trim();

--- a/src/server.ts
+++ b/src/server.ts
@@ -43,7 +43,7 @@ export class AutonomousAIServer {
     });
 
     // Execute tool calls
-    this.server.setRequestHandler(CallToolRequestSchema, async (request, _extra) => {
+    this.server.setRequestHandler(CallToolRequestSchema, async (request, _extra: unknown): Promise<any> => {
       const { name, arguments: args } = request.params;
 
       try {
@@ -59,18 +59,18 @@ export class AutonomousAIServer {
     });
 
     // List available resources
-    this.server.setRequestHandler('resources/list' as any, async () => {
+    this.server.setRequestHandler('resources/list' as any, async (): Promise<any> => {
       return this.resourceManager.listResources();
     });
 
     // Read resource content
-    this.server.setRequestHandler('resources/read' as any, async (request: any) => {
+    this.server.setRequestHandler('resources/read' as any, async (request: any): Promise<any> => {
       const { uri } = request.params;
       return this.resourceManager.readResource(uri);
     });
 
     // Error handling
-    this.server.onerror = (error) => {
+    this.server.onerror = (error: unknown) => {
       console.error('[MCP Error]', error);
     };
 

--- a/src/tools/web/web-tools.ts
+++ b/src/tools/web/web-tools.ts
@@ -91,7 +91,7 @@ export class WebTools extends BaseTool {
       const $ = cheerio.load(response.data) as cheerio.CheerioAPI;
       $('script, style, noscript').remove();
       
-      const textContent = $.text()
+      const textContent = $.root().text()
         .replace(/\s+/g, ' ')
         .replace(/\n\s*\n/g, '\n')
         .trim();
@@ -261,11 +261,11 @@ export class WebTools extends BaseTool {
           });
         });
         
-        root.querySelectorAll('a[href]').forEach((link: HTMLAnchorElement) => {
+        (root.querySelectorAll('a[href]') as NodeListOf<HTMLAnchorElement>).forEach((anchor) => {
           analysis.links.push({
-            href: link.getAttribute('href'),
-            text: link.textContent?.trim().substring(0, 50),
-            isExternal: link.getAttribute('href')?.startsWith('http'),
+            href: anchor.getAttribute('href'),
+            text: anchor.textContent?.trim().substring(0, 50),
+            isExternal: anchor.getAttribute('href')?.startsWith('http'),
           });
         });
         


### PR DESCRIPTION
## Summary
- fix Cheerio text extraction using `root().text()`
- refine server request handler types
- correct DOM link gathering logic

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'fs-extra', etc.)*
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a041d66bc8329a64c812313b93b1b